### PR TITLE
Bump nokogiri to 1.19.3 (closes last 2 production alerts)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.16.3)
+    ffi (1.17.4)
     forwardable-extended (2.6.0)
     google-protobuf (4.35.0)
       bigdecimal
@@ -59,7 +59,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
     mini_portile2 (2.8.9)
-    nokogiri (1.18.10)
+    nokogiri (1.19.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     nuggets (1.6.1)


### PR DESCRIPTION
## Summary
- Bumps `nokogiri` from `1.18.10` to `1.19.3` in `Gemfile.lock`.
- Closes the last 2 open production-facing Dependabot alerts.
- Unblocked by the prior workflow change bumping CI Ruby from `3.1` to `3.3` (nokogiri 1.19+ requires Ruby ≥3.2).

## Closed alerts
| Severity | GHSA | Issue |
|---|---|---|
| high | GHSA-c4rq-3m3g-8wgx | nokogiri CSS selector tokenizer ReDoS |
| medium | GHSA-v2fc-qm4h-8hqv | nokogiri XSLT memory leak |

## Incidental
- `ffi 1.16.3 → 1.17.4` — required because 1.16.x doesn't build on Ruby 3.3.

## Test plan
- [x] `bundle exec jekyll build` succeeds locally on Ruby 3.3.11
- [ ] Pages deploy succeeds on `main` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)