### PR TITLE
Override liquidjs to patch critical RCE + 7 other alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1878,9 +1878,9 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "10.17.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.17.0.tgz",
-      "integrity": "sha512-M4MC5/nencttIJHirl5jFTkl7Yu+grIDLn3Qgl7BPAD3BsbTCQknDxlG5VXWRwslWIjk8lSZZjVq9LioILDk1Q==",
+      "version": "10.27.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.0.tgz",
+      "integrity": "sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1891,7 +1891,7 @@
         "liquidjs": "bin/liquid.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       },
       "funding": {
         "type": "opencollective",
@@ -3114,7 +3114,7 @@
         "esbuild": "^0.13.10",
         "js-base64": "^3.6.1",
         "kramed": "^0.5.6",
-        "liquidjs": "10.17.0",
+        "liquidjs": "^10.26.0",
         "slugify": "^1.5.3"
       }
     },
@@ -4287,9 +4287,9 @@
       "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ=="
     },
     "liquidjs": {
-      "version": "10.17.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.17.0.tgz",
-      "integrity": "sha512-M4MC5/nencttIJHirl5jFTkl7Yu+grIDLn3Qgl7BPAD3BsbTCQknDxlG5VXWRwslWIjk8lSZZjVq9LioILDk1Q==",
+      "version": "10.27.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.0.tgz",
+      "integrity": "sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==",
       "dev": true,
       "requires": {
         "commander": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
   },
   "dependencies": {
     "@bookshop/generate": "^3.18.2"
+  },
+  "overrides": {
+    "liquidjs": "^10.26.0"
   }
 }


### PR DESCRIPTION
## Summary
- Adds an npm `overrides` block forcing `liquidjs` to `^10.26.0`.
- Closes **8 of the remaining 16 dev-only Dependabot alerts** in one PR, including the **critical RCE** (#77).

## Why an override
`@bookshop/jekyll-engine` pins liquidjs at the exact version `10.17.0` in its `package.json` (no caret), so `npm install` alone can't pull in any patched version. `overrides` is the standard npm mechanism for this exact situation.

## Closed alerts
| Severity | GHSA | Issue |
|---|---|---|
| critical | GHSA-gf2q-c269-pqgc | LiquidJS RCE |
| high | GHSA-wmfp-5q7x-987x | path traversal fallback |
| high | GHSA-56p5-8mhr-2fph | root-restriction bypass via symlinks |
| medium | GHSA-9x9p-qf8f-mvjg | `{% render %}` ownPropertyOnly bypass |
| medium | GHSA-2qv6-9wx5-cwv4 | `strip_html` filter newline XSS |
| medium | GHSA-v273-448j-v4qj | `renderFile()`/`parseFile()` root bypass |
| medium | GHSA-rv5g-f82m-qrvv | `sort_natural` ownPropertyOnly bypass |
| medium | GHSA-45rm-2893-5f49 | prototype property leak |

## Why not also override svelte / esbuild
- **svelte**: Bookshop is on Svelte 4.x. The open svelte advisories all want 5.x patches that haven't been backported. Bumping to 5.x would break Bookshop.
- **esbuild**: Bookshop pins `^0.13.10`. Latest is `0.25.x`. Crossing 12 minor versions of a 0.x bundler is high-risk — defer until Bookshop upstream moves.

## Test plan
- [x] `npm run bookshop-dev` boots cleanly with `liquidjs@10.27.0`
- [x] `bundle exec jekyll build` succeeds on Ruby 3.3
- [ ] Pages deploy succeeds on `main` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)